### PR TITLE
Make the readUPTCData function public

### DIFF
--- a/lib/IptcParser.ts
+++ b/lib/IptcParser.ts
@@ -68,7 +68,7 @@ export class IptcParser {
   }
 
 
-  private static readIPTCData(buffer: BufferType, start: number, length: number): IptcData {
+  public static readIPTCData(buffer: BufferType, start: number = 0, length: number = buffer.length): IptcData {
     const data: IptcData = {};
 
     if (buffer.slice(start, start + 13).toString("utf-8") != "Photoshop 3.0") {


### PR DESCRIPTION
Make the `readUPTCData` function public, with default values for the "start" and "length" arguments.

This is so that ts-node-iptc can be used along with other image libraries that may have already read in the image and exposed the various buffers in the file, including iptc.  In specific, the **sharp** image library ( https://github.com/lovell/sharp ) exposes the metadata from image files it loads, but it does not parse them (exif, iptc, etc.).  This change let's me not reload the image and parse the buffer I've already got.